### PR TITLE
Feat/fab-import-target

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^20",
+    "@types/pg": "^8.15.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.11
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.15.5
       '@types/react':
         specifier: ^19
         version: 19.1.10
@@ -4159,7 +4162,6 @@ snapshots:
       '@types/node': 20.19.11
       pg-protocol: 1.10.3
       pg-types: 2.2.0
-    optional: true
 
   '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:

--- a/src/app/api/auth/test-login/route.ts
+++ b/src/app/api/auth/test-login/route.ts
@@ -1,6 +1,7 @@
-import { clearSession, getSessionOrNull, setSession } from '@/lib/session';
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
+
+import { clearSession, getSessionOrNull, setSession } from '@/lib/session';
 
 const Body = z.object({ code: z.string().min(1) });
 

--- a/src/app/api/imports/tabs/route.ts
+++ b/src/app/api/imports/tabs/route.ts
@@ -1,7 +1,8 @@
-import { ImportsTabsBodySchema, handleImportsTabs } from '@/lib/imports/handle-imports-tabs';
-import { getSessionOrNull } from '@/lib/session';
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
+
+import { handleImportsTabs,ImportsTabsBodySchema } from '@/lib/imports/handle-imports-tabs';
+import { getSessionOrNull } from '@/lib/session';
 
 const HeadersSchema = z.object({
   tsApiVersion: z.string().nonempty(),

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,0 +1,8 @@
+export default function InboxPage() {
+	return (
+		<div className="min-h-[60svh] p-6">
+			<h1 className="mb-4 text-2xl font-bold">Inbox</h1>
+			<p className="text-muted-foreground">這裡會顯示匯入的分頁清單（MVP 先放置佔位）。</p>
+		</div>
+	);
+}

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { Fab } from '@/components/fab/fab';
 import { type ImportTarget,ImportTargetDialog } from '@/components/fab/import-target-dialog';
+import { ApiError } from '@/lib/api/errors';
 import { postImportsTabs } from '@/lib/api/imports-client';
 
 export default function InboxPage() {
@@ -21,12 +22,11 @@ export default function InboxPage() {
 				{ idempotencyKey: crypto.randomUUID() },
 			);
 		} catch (err) {
-			// @ts-expect-error check unauthorized flag from client
-			if ((err as any)?.isUnauthorized) {
+			if (err instanceof ApiError && err.isUnauthorized) {
 				window.location.href = '/login';
 				return;
 			}
-			throw err;
+			throw err as Error;
 		}
 	};
 

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -10,16 +10,24 @@ export default function InboxPage() {
 	const [open, setOpen] = useState(false);
 
 	const handleConfirm = async (target: ImportTarget) => {
-		// TODO: 串接瀏覽器擴充讀取全部開啟分頁
-		const tabs = [{ url: window.location.href, title: document.title }];
-		await postImportsTabs(
-			{
-				tabs,
-				target: target.type === 'inbox' ? { inbox: true } : { boardId: target.boardId },
-				closeImported: false,
-			},
-			{ idempotencyKey: crypto.randomUUID() },
-		);
+		try {
+			const tabs = [{ url: window.location.href, title: document.title }];
+			await postImportsTabs(
+				{
+					tabs,
+					target: target.type === 'inbox' ? { inbox: true } : { boardId: target.boardId },
+					closeImported: false,
+				},
+				{ idempotencyKey: crypto.randomUUID() },
+			);
+		} catch (err) {
+			// @ts-expect-error check unauthorized flag from client
+			if ((err as any)?.isUnauthorized) {
+				window.location.href = '/login';
+				return;
+			}
+			throw err;
+		}
 	};
 
 	return (

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 
 import { Fab } from '@/components/fab/fab';
-import { ImportTargetDialog, type ImportTarget } from '@/components/fab/import-target-dialog';
+import { type ImportTarget,ImportTargetDialog } from '@/components/fab/import-target-dialog';
 import { postImportsTabs } from '@/lib/api/imports-client';
 
 export default function InboxPage() {

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -4,13 +4,22 @@ import { useState } from 'react';
 
 import { Fab } from '@/components/fab/fab';
 import { ImportTargetDialog, type ImportTarget } from '@/components/fab/import-target-dialog';
+import { postImportsTabs } from '@/lib/api/imports-client';
 
 export default function InboxPage() {
 	const [open, setOpen] = useState(false);
 
-	const handleConfirm = async (_target: ImportTarget) => {
-		// 後續會呼叫 imports API，這步先佔位
-		await new Promise((r) => setTimeout(r, 300));
+	const handleConfirm = async (target: ImportTarget) => {
+		// TODO: 串接瀏覽器擴充讀取全部開啟分頁
+		const tabs = [{ url: window.location.href, title: document.title }];
+		await postImportsTabs(
+			{
+				tabs,
+				target: target.type === 'inbox' ? { inbox: true } : { boardId: target.boardId },
+				closeImported: false,
+			},
+			{ idempotencyKey: crypto.randomUUID() },
+		);
 	};
 
 	return (

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,8 +1,25 @@
+"use client";
+
+import { useState } from 'react';
+
+import { Fab } from '@/components/fab/fab';
+import { ImportTargetDialog, type ImportTarget } from '@/components/fab/import-target-dialog';
+
 export default function InboxPage() {
+	const [open, setOpen] = useState(false);
+
+	const handleConfirm = async (_target: ImportTarget) => {
+		// 後續會呼叫 imports API，這步先佔位
+		await new Promise((r) => setTimeout(r, 300));
+	};
+
 	return (
 		<div className="min-h-[60svh] p-6">
 			<h1 className="mb-4 text-2xl font-bold">Inbox</h1>
 			<p className="text-muted-foreground">這裡會顯示匯入的分頁清單（MVP 先放置佔位）。</p>
+
+			<Fab label="匯入分頁" onClick={() => setOpen(true)} />
+			<ImportTargetDialog open={open} onOpenChange={setOpen} onConfirm={handleConfirm} />
 		</div>
 	);
 }

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -10,15 +10,24 @@ export default function KanbanIndexPage() {
 	const [open, setOpen] = useState(false);
 
 	const handleConfirm = async (target: ImportTarget) => {
-		const tabs = [{ url: window.location.href, title: document.title }];
-		await postImportsTabs(
-			{
-				tabs,
-				target: target.type === 'inbox' ? { inbox: true } : { boardId: target.boardId },
-				closeImported: false,
-			},
-			{ idempotencyKey: crypto.randomUUID() },
-		);
+		try {
+			const tabs = [{ url: window.location.href, title: document.title }];
+			await postImportsTabs(
+				{
+					tabs,
+					target: target.type === 'inbox' ? { inbox: true } : { boardId: target.boardId },
+					closeImported: false,
+				},
+				{ idempotencyKey: crypto.randomUUID() },
+			);
+		} catch (err) {
+			// @ts-expect-error check unauthorized flag from client
+			if ((err as any)?.isUnauthorized) {
+				window.location.href = '/login';
+				return;
+			}
+			throw err;
+		}
 	};
 
 	return (

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 
 import { Fab } from '@/components/fab/fab';
-import { ImportTargetDialog, type ImportTarget } from '@/components/fab/import-target-dialog';
+import { type ImportTarget,ImportTargetDialog } from '@/components/fab/import-target-dialog';
 import { postImportsTabs } from '@/lib/api/imports-client';
 
 export default function KanbanIndexPage() {

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { Fab } from '@/components/fab/fab';
 import { type ImportTarget,ImportTargetDialog } from '@/components/fab/import-target-dialog';
+import { ApiError } from '@/lib/api/errors';
 import { postImportsTabs } from '@/lib/api/imports-client';
 
 export default function KanbanIndexPage() {
@@ -21,12 +22,11 @@ export default function KanbanIndexPage() {
 				{ idempotencyKey: crypto.randomUUID() },
 			);
 		} catch (err) {
-			// @ts-expect-error check unauthorized flag from client
-			if ((err as any)?.isUnauthorized) {
+			if (err instanceof ApiError && err.isUnauthorized) {
 				window.location.href = '/login';
 				return;
 			}
-			throw err;
+			throw err as Error;
 		}
 	};
 

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -1,0 +1,8 @@
+export default function KanbanIndexPage() {
+	return (
+		<div className="min-h-[60svh] p-6">
+			<h1 className="mb-4 text-2xl font-bold">Kanban</h1>
+			<p className="text-muted-foreground">這裡會顯示 Kanban 列表與進入各看板（MVP 佔位）。</p>
+		</div>
+	);
+}

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -1,8 +1,25 @@
+"use client";
+
+import { useState } from 'react';
+
+import { Fab } from '@/components/fab/fab';
+import { ImportTargetDialog, type ImportTarget } from '@/components/fab/import-target-dialog';
+
 export default function KanbanIndexPage() {
+	const [open, setOpen] = useState(false);
+
+	const handleConfirm = async (_target: ImportTarget) => {
+		// 後續會呼叫 imports API，這步先佔位
+		await new Promise((r) => setTimeout(r, 300));
+	};
+
 	return (
 		<div className="min-h-[60svh] p-6">
 			<h1 className="mb-4 text-2xl font-bold">Kanban</h1>
 			<p className="text-muted-foreground">這裡會顯示 Kanban 列表與進入各看板（MVP 佔位）。</p>
+
+			<Fab label="匯入分頁" onClick={() => setOpen(true)} />
+			<ImportTargetDialog open={open} onOpenChange={setOpen} onConfirm={handleConfirm} />
 		</div>
 	);
 }

--- a/src/app/kanban/page.tsx
+++ b/src/app/kanban/page.tsx
@@ -4,13 +4,21 @@ import { useState } from 'react';
 
 import { Fab } from '@/components/fab/fab';
 import { ImportTargetDialog, type ImportTarget } from '@/components/fab/import-target-dialog';
+import { postImportsTabs } from '@/lib/api/imports-client';
 
 export default function KanbanIndexPage() {
 	const [open, setOpen] = useState(false);
 
-	const handleConfirm = async (_target: ImportTarget) => {
-		// 後續會呼叫 imports API，這步先佔位
-		await new Promise((r) => setTimeout(r, 300));
+	const handleConfirm = async (target: ImportTarget) => {
+		const tabs = [{ url: window.location.href, title: document.title }];
+		await postImportsTabs(
+			{
+				tabs,
+				target: target.type === 'inbox' ? { inbox: true } : { boardId: target.boardId },
+				closeImported: false,
+			},
+			{ idempotencyKey: crypto.randomUUID() },
+		);
 	};
 
 	return (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { postTestLogin } from '@/lib/api/auth-client';
+
+export default function LoginPage() {
+	const [code, setCode] = useState("");
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		setIsLoading(true);
+		try {
+			await postTestLogin({ code });
+			window.location.href = "/inbox";
+		} catch (err) {
+			setError((err as Error).message);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<div className="mx-auto max-w-md p-6">
+			<h1 className="mb-4 text-2xl font-bold">登入</h1>
+			<p className="mb-4 text-sm text-muted-foreground">輸入測試碼以登入 TabSeed。</p>
+			<form onSubmit={handleSubmit} className="space-y-3">
+				<Input
+					placeholder="輸入測試碼"
+					value={code}
+					onChange={(e) => setCode(e.target.value)}
+					required
+				/>
+				<div className="flex items-center gap-2">
+					<Button type="submit" disabled={isLoading}>
+						{isLoading ? "登入中..." : "登入"}
+					</Button>
+					<a className="text-sm text-primary underline" href="/">
+						回首頁
+					</a>
+				</div>
+				{error ? <div className="text-sm text-destructive">{error}</div> : null}
+			</form>
+		</div>
+	);
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from 'next/link';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -40,9 +41,9 @@ export default function LoginPage() {
 					<Button type="submit" disabled={isLoading}>
 						{isLoading ? "登入中..." : "登入"}
 					</Button>
-					<a className="text-sm text-primary underline" href="/">
+					<Link className="text-sm text-primary underline" href="/">
 						回首頁
-					</a>
+					</Link>
 				</div>
 				{error ? <div className="text-sm text-destructive">{error}</div> : null}
 			</form>

--- a/src/components/fab/fab.tsx
+++ b/src/components/fab/fab.tsx
@@ -1,0 +1,27 @@
+import { Plus } from 'lucide-react';
+import { forwardRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface FabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	readonly label?: string;
+}
+
+export const Fab = forwardRef<HTMLButtonElement, FabProps>(function Fab(
+	{ className, label = 'Add', ...props },
+	ref,
+) {
+	return (
+		<button
+			ref={ref}
+			className={cn(
+				'fixed bottom-6 right-6 inline-flex items-center gap-2 rounded-full bg-primary px-5 py-3 text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+				className,
+			)}
+			{...props}
+		>
+			<Plus className="h-5 w-5" />
+			<span className="hidden sm:inline text-sm font-medium">{label}</span>
+		</button>
+	);
+});

--- a/src/components/fab/fab.tsx
+++ b/src/components/fab/fab.tsx
@@ -20,8 +20,8 @@ export const Fab = forwardRef<HTMLButtonElement, FabProps>(function Fab(
 			)}
 			{...props}
 		>
-			<Plus className="h-5 w-5" />
-			<span className="hidden sm:inline text-sm font-medium">{label}</span>
+			<Plus className="size-5" />
+			<span className="hidden text-sm font-medium sm:inline">{label}</span>
 		</button>
 	);
 });

--- a/src/components/fab/import-target-dialog.tsx
+++ b/src/components/fab/import-target-dialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Fragment, useState } from 'react';
+import { ChevronDown, Inbox, Layout, Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export type ImportTarget =
+	| { type: 'inbox' }
+	| { type: 'kanban'; boardId?: string };
+
+interface ImportTargetDialogProps {
+	readonly open: boolean;
+	readonly onOpenChange: (open: boolean) => void;
+	readonly onConfirm: (target: ImportTarget) => Promise<void> | void;
+}
+
+export function ImportTargetDialog({ open, onOpenChange, onConfirm }: ImportTargetDialogProps) {
+	const [isLoading, setIsLoading] = useState(false);
+	const [target, setTarget] = useState<ImportTarget>({ type: 'inbox' });
+
+	const handleConfirm = async () => {
+		try {
+			setIsLoading(true);
+			await onConfirm(target);
+			onOpenChange(false);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	if (!open) return null;
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+			<div
+				className="absolute inset-0 bg-black/40"
+				onClick={() => onOpenChange(false)}
+				aria-hidden
+			/>
+			<div className="relative z-10 w-full max-w-md rounded-lg border bg-background p-4 shadow-2xl">
+				<h2 className="mb-3 text-lg font-semibold">匯入目標</h2>
+				<div className="space-y-2">
+					<button
+						className={cn(
+							'flex w-full items-center gap-3 rounded-md border p-3 text-left hover:bg-accent',
+							target.type === 'inbox' && 'border-primary bg-primary/5',
+						)}
+						onClick={() => setTarget({ type: 'inbox' })}
+					>
+						<Inbox className="h-5 w-5" />
+						<div>
+							<div className="font-medium">Inbox</div>
+							<div className="text-xs text-muted-foreground">匯入到收件匣</div>
+						</div>
+					</button>
+
+					<button
+						className={cn(
+							'flex w-full items-center justify-between rounded-md border p-3 text-left hover:bg-accent',
+							target.type === 'kanban' && 'border-primary bg-primary/5',
+						)}
+						onClick={() => setTarget({ type: 'kanban' })}
+					>
+						<span className="inline-flex items-center gap-3">
+							<Layout className="h-5 w-5" />
+							<span>
+								<div className="font-medium">Kanban</div>
+								<div className="text-xs text-muted-foreground">匯入到指定看板</div>
+							</span>
+						</span>
+						<ChevronDown className="h-4 w-4 opacity-60" />
+					</button>
+
+					{target.type === 'kanban' ? (
+						<div className="rounded-md border p-3">
+							<label className="mb-1 block text-xs text-muted-foreground">選擇看板（MVP 先以假資料）</label>
+							<div className="grid grid-cols-2 gap-2">
+								{[
+									{ id: 'board-1', name: 'Product' },
+									{ id: 'board-2', name: 'Research' },
+									{ id: 'board-3', name: 'Personal' },
+								].map((b) => (
+									<button
+										key={b.id}
+										className={cn(
+											'rounded-md border p-2 text-sm hover:bg-accent',
+											target.type === 'kanban' && target.boardId === b.id && 'border-primary bg-primary/5',
+										)}
+										onClick={() => setTarget({ type: 'kanban', boardId: b.id })}
+									>
+										{b.name}
+									</button>
+								))}
+							</div>
+						</div>
+					) : null}
+				</div>
+
+				<div className="mt-4 flex justify-end gap-2">
+					<Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isLoading}>
+						取消
+					</Button>
+					<Button onClick={handleConfirm} disabled={isLoading}>
+						{isLoading ? (
+							<Fragment>
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								匯入中
+							</Fragment>
+						) : (
+							'確認'
+						)}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/fab/import-target-dialog.tsx
+++ b/src/components/fab/import-target-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Fragment, useState } from 'react';
 import { ChevronDown, Inbox, Layout, Loader2 } from 'lucide-react';
+import { Fragment, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -49,7 +49,7 @@ export function ImportTargetDialog({ open, onOpenChange, onConfirm }: ImportTarg
 						)}
 						onClick={() => setTarget({ type: 'inbox' })}
 					>
-						<Inbox className="h-5 w-5" />
+						<Inbox className="size-5" />
 						<div>
 							<div className="font-medium">Inbox</div>
 							<div className="text-xs text-muted-foreground">匯入到收件匣</div>
@@ -64,13 +64,13 @@ export function ImportTargetDialog({ open, onOpenChange, onConfirm }: ImportTarg
 						onClick={() => setTarget({ type: 'kanban' })}
 					>
 						<span className="inline-flex items-center gap-3">
-							<Layout className="h-5 w-5" />
+							<Layout className="size-5" />
 							<span>
 								<div className="font-medium">Kanban</div>
 								<div className="text-xs text-muted-foreground">匯入到指定看板</div>
 							</span>
 						</span>
-						<ChevronDown className="h-4 w-4 opacity-60" />
+						<ChevronDown className="size-4 opacity-60" />
 					</button>
 
 					{target.type === 'kanban' ? (
@@ -105,7 +105,7 @@ export function ImportTargetDialog({ open, onOpenChange, onConfirm }: ImportTarg
 					<Button onClick={handleConfirm} disabled={isLoading}>
 						{isLoading ? (
 							<Fragment>
-								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								<Loader2 className="mr-2 size-4 animate-spin" />
 								匯入中
 							</Fragment>
 						) : (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/lib/api/auth-client.ts
+++ b/src/lib/api/auth-client.ts
@@ -1,0 +1,20 @@
+"use client";
+
+export async function postTestLogin({ code }: { code: string }): Promise<void> {
+	const res = await fetch('/api/auth/test-login', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ code }),
+		cache: 'no-store',
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`Login failed: ${res.status} ${text}`);
+	}
+}
+
+export async function getSession(): Promise<{ session: unknown } | null> {
+	const res = await fetch('/api/auth/test-login', { cache: 'no-store' });
+	if (!res.ok) return null;
+	return (await res.json()) as { session: unknown };
+}

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,15 @@
+export class ApiError extends Error {
+	public readonly status: number;
+	public readonly body: string;
+
+	public constructor(message: string, status: number, body: string) {
+		super(message);
+		this.name = 'ApiError';
+		this.status = status;
+		this.body = body;
+	}
+
+	public get isUnauthorized(): boolean {
+		return this.status === 401;
+	}
+}

--- a/src/lib/api/imports-client.ts
+++ b/src/lib/api/imports-client.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { ApiError } from '@/lib/api/errors';
 import type { ImportsTabsBody } from '@/lib/imports/handle-imports-tabs';
 
 const API_VERSION = '2025-08-19';
@@ -27,11 +28,7 @@ export async function postImportsTabs(
 
 	if (!res.ok) {
 		const errText = await res.text();
-		const err = new Error(`POST /api/imports/tabs failed: ${res.status} ${errText}`);
-		// 在呼叫端可依據此旗標導向登入頁
-		// @ts-expect-error mark auth error for caller
-		(err as any).isUnauthorized = res.status === 401;
-		throw err;
+		throw new ApiError(`POST /api/imports/tabs failed`, res.status, errText);
 	}
 	return (await res.json()) as ImportsTabsResponse;
 }

--- a/src/lib/api/imports-client.ts
+++ b/src/lib/api/imports-client.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import type { ImportsTabsBody } from '@/lib/imports/handle-imports-tabs';
+
+const API_VERSION = '2025-08-19';
+
+export type ImportsTabsResponse = {
+	created: Array<{ id: string; url: string; title?: string; etag: string }>;
+	reused: Array<{ id: string; url: string; title?: string; etag: string }>;
+	ignored: Array<{ id: string; url: string; title?: string; etag: string }>;
+};
+
+export async function postImportsTabs(
+	body: ImportsTabsBody,
+	options?: { idempotencyKey?: string },
+): Promise<ImportsTabsResponse> {
+	const res = await fetch('/api/imports/tabs', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'TS-API-Version': API_VERSION,
+			...(options?.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : {}),
+		},
+		body: JSON.stringify(body),
+		cache: 'no-store',
+	});
+
+	if (!res.ok) {
+		const errText = await res.text();
+		throw new Error(`POST /api/imports/tabs failed: ${res.status} ${errText}`);
+	}
+	return (await res.json()) as ImportsTabsResponse;
+}

--- a/src/lib/api/imports-client.ts
+++ b/src/lib/api/imports-client.ts
@@ -27,7 +27,11 @@ export async function postImportsTabs(
 
 	if (!res.ok) {
 		const errText = await res.text();
-		throw new Error(`POST /api/imports/tabs failed: ${res.status} ${errText}`);
+		const err = new Error(`POST /api/imports/tabs failed: ${res.status} ${errText}`);
+		// 在呼叫端可依據此旗標導向登入頁
+		// @ts-expect-error mark auth error for caller
+		(err as any).isUnauthorized = res.status === 401;
+		throw err;
 	}
 	return (await res.json()) as ImportsTabsResponse;
 }

--- a/src/lib/data/idempotency-repository.ts
+++ b/src/lib/data/idempotency-repository.ts
@@ -1,7 +1,9 @@
-import type { DbClient } from '@/lib/db/client';
-import { schema } from '@/lib/db/client';
 import { eq, lt } from 'drizzle-orm';
 import { ulid } from 'ulid';
+
+import type { DbClient } from '@/lib/db/client';
+import { schema } from '@/lib/db/client';
+
 import type { ImportResult } from './store';
 
 export interface IdempotencyRepository {

--- a/src/lib/data/repository.ts
+++ b/src/lib/data/repository.ts
@@ -1,7 +1,9 @@
-import type { DbClient } from '@/lib/db/client';
-import { schema } from '@/lib/db/client';
 import { eq } from 'drizzle-orm';
 import { ulid } from 'ulid';
+
+import type { DbClient } from '@/lib/db/client';
+import { schema } from '@/lib/db/client';
+
 import type { TabSeedTab } from './store';
 
 export interface TabsRepository {

--- a/src/lib/data/store.ts
+++ b/src/lib/data/store.ts
@@ -1,4 +1,5 @@
 import { ulid } from 'ulid';
+
 import type { IdempotencyRepository } from './idempotency-repository';
 
 export interface TabSeedTab {

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,6 +1,8 @@
 import 'dotenv/config';
+
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
+
 import * as schema from './schema';
 
 const DATABASE_URL = process.env.DATABASE_URL;

--- a/src/lib/imports/handle-imports-tabs.test.ts
+++ b/src/lib/imports/handle-imports-tabs.test.ts
@@ -7,12 +7,9 @@ import { handleImportsTabs, ImportsTabsBodySchema } from './handle-imports-tabs'
 
 describe('handleImportsTabs', () => {
   beforeEach(() => {
-    // @ts-expect-error testing: access private store internals to reset state between tests
     (store as any).tabs?.clear?.();
-    // @ts-expect-error testing: access private store internals to reset state between tests
     (store as any).byOwnerAndUrl?.clear?.();
-    // @ts-expect-error testing: access private store internals to reset state between tests
-    (store as any).idempotency?.clear?.();
+    (store as any).memoryIdempotency?.clear?.();
   });
 
   it('validates body schema', () => {

--- a/src/lib/imports/handle-imports-tabs.test.ts
+++ b/src/lib/imports/handle-imports-tabs.test.ts
@@ -1,14 +1,17 @@
-import { store } from '@/lib/data/store';
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import { store } from '@/lib/data/store';
+
 import { handleImportsTabs, ImportsTabsBodySchema } from './handle-imports-tabs';
 
 describe('handleImportsTabs', () => {
   beforeEach(() => {
-    // @ts-expect-error access private for resetting in tests via any
+    // @ts-expect-error testing: access private store internals to reset state between tests
     (store as any).tabs?.clear?.();
-    // @ts-expect-error
+    // @ts-expect-error testing: access private store internals to reset state between tests
     (store as any).byOwnerAndUrl?.clear?.();
-    // @ts-expect-error
+    // @ts-expect-error testing: access private store internals to reset state between tests
     (store as any).idempotency?.clear?.();
   });
 

--- a/src/lib/imports/handle-imports-tabs.ts
+++ b/src/lib/imports/handle-imports-tabs.ts
@@ -99,7 +99,7 @@ export async function handleImportsTabsAsync(
   const { idempotencyKey, ownerId, body } = input;
 
   if (idempotencyKey) {
-    const cached = store.getIdempotentResult(idempotencyKey);
+    const cached = await store.getIdempotentResult(idempotencyKey);
     if (cached) return cached.response;
   }
 

--- a/src/lib/imports/handle-imports-tabs.ts
+++ b/src/lib/imports/handle-imports-tabs.ts
@@ -1,11 +1,9 @@
-import { store, type ImportResult } from '@/lib/data/store';
-import { normalizeUrl } from '@/lib/url/normalize-url';
 import { z } from 'zod';
-import type { TabsRepository } from '@/lib/data/repository';
-import { DbTabsRepository } from '@/lib/data/repository';
-import type { IdempotencyRepository } from '@/lib/data/idempotency-repository';
+
 import { DbIdempotencyRepository } from '@/lib/data/idempotency-repository';
+import { type ImportResult,store } from '@/lib/data/store';
 import { db } from '@/lib/db/client';
+import { normalizeUrl } from '@/lib/url/normalize-url';
 
 // Initialize DB idempotency repository if possible
 try {

--- a/src/lib/url/normalize-url.test.ts
+++ b/src/lib/url/normalize-url.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+
 import { isDuplicate, normalizeUrl } from './normalize-url';
 
 // Helper

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
## Background (Why)

We need to provide users with basic tab import functionality, allowing users to batch import tabs into Inbox or Kanban boards.

## Implementation Approach (How)

Using component-based design, I created reusable FAB components and Dialogs, integrating with the existing `/api/imports/tabs` API. Error handling uses a unified ApiError class to provide good 401 auto-redirect experience. Page routing follows Next.js App Router conventions, and login uses a test code mechanism to support early alpha testing.

## Actual Changes (What was done)

- [x] **Page Skeleton**: Created `/inbox` and `/kanban` pages as mounting points for + FAB
- [x] **Reusable FAB Component**: Fixed-position circular + button, supports label and responsive hiding
- [x] **Import Target Selection Dialog**: Supports Inbox/Kanban selection, includes mock board list
- [x] **Frontend imports client**: Encapsulates `POST /api/imports/tabs` calls, including idempotency key
- [x] **Login Page `/login`**: Test code login flow, resolves 401 unauthorized issues
- [x] **Unified Error Handling**: ApiError class + 401 auto-redirect to login page mechanism

### Screenshots or Video Reference

### Testing Validation

- [x] **Basic Flow**: Inbox/Kanban pages display + FAB, clicking opens target selection Dialog
- [x] **Target Selection**: Can select Inbox or Kanban, Kanban shows board options
- [x] **Login Flow**: `/login` page allows test code login and redirects to `/inbox`
- [x] **401 Handling**: When not logged in, clicking confirm auto-redirects to `/login` page
- [x] **API Integration**: Successful import calls `POST /api/imports/tabs` (currently simulated with current page)
- [x] **TypeScript**: No type errors, ESLint has only 1 warning remaining

## Additional Notes

- **Data Display**: Currently, after successful import, frontend won't display the list, needs subsequent ticket to implement GET tabs API and list UI
- **Data Persistence**: Currently using in-memory store, data will disappear after dev server restart, production environment will use PostgreSQL
- **Test Code Setup**: Need to set `TEST_LOGIN_CODES=your_code` in `.env.local` to login
- **Browser Extension**: Currently using `window.location.href` + `document.title` to simulate 1 tab, future will integrate with real browser API
