### PR TITLE
Feat/import-empty-tabs-toast

### DIFF
--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Plus } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 import { type ImportTarget, ImportTargetDialog } from '@/components/fab/import-to-inbox-dialog';
 import { ManualImportDialog } from '@/components/fab/manual-import-dialog';

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -51,10 +51,10 @@ export default function InboxPage() {
         setOpen(false);
         addToast({
           variant: 'warning',
-          title: '找不到可匯入的分頁',
-          description: '目前沒有可匯入的分頁。要改用手動匯入嗎？',
+          title: 'No tabs to import',
+          description: 'There are no importable tabs right now. Want to import manually instead?',
           linkHref: '?manualImport=1',
-          linkLabel: '開啟手動匯入',
+          linkLabel: 'Open manual import',
           durationMs: 8000,
         });
         return;

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -52,7 +52,7 @@ export default function InboxPage() {
         addToast({
           variant: 'warning',
           title: 'No tabs to import',
-          description: 'There are no importable tabs right now. Want to import manually instead?',
+          description: 'There are no importable tabs right now.',
           linkHref: '?manualImport=1',
           linkLabel: 'Open manual import',
           durationMs: 8000,

--- a/src/app/kanban/[boardId]/page.tsx
+++ b/src/app/kanban/[boardId]/page.tsx
@@ -341,7 +341,7 @@ export default function KanbanBoardPage() {
                 addToast({
                   variant: 'warning',
                   title: 'No tabs to import',
-                  description: 'There are no importable tabs right now. Want to import manually instead?',
+                  description: 'There are no importable tabs right now.',
                   linkHref: `?manualImport=1${columnId ? `&columnId=${encodeURIComponent(columnId)}` : ''}`,
                   linkLabel: 'Open manual import',
                   durationMs: 8000,

--- a/src/app/kanban/[boardId]/page.tsx
+++ b/src/app/kanban/[boardId]/page.tsx
@@ -340,10 +340,10 @@ export default function KanbanBoardPage() {
                 setOpenImportDialog(false);
                 addToast({
                   variant: 'warning',
-                  title: '找不到可匯入的分頁',
-                  description: '目前沒有可匯入的分頁。要改用手動匯入嗎？',
+                  title: 'No tabs to import',
+                  description: 'There are no importable tabs right now. Want to import manually instead?',
                   linkHref: `?manualImport=1${columnId ? `&columnId=${encodeURIComponent(columnId)}` : ''}`,
-                  linkLabel: '開啟手動匯入',
+                  linkLabel: 'Open manual import',
                   durationMs: 8000,
                 });
                 return;
@@ -380,10 +380,10 @@ export default function KanbanBoardPage() {
               setOpenImportDialog(false);
               addToast({
                 variant: 'warning',
-                title: '未偵測到擴充或分頁',
-                description: '請改用手動匯入將連結加入此欄位。',
+                title: 'Extension not detected',
+                description: 'Please use manual import to add links into this column.',
                 linkHref: `?manualImport=1${targetColumnId ? `&columnId=${encodeURIComponent(targetColumnId)}` : ''}`,
-                linkLabel: '開啟手動匯入',
+                linkLabel: 'Open manual import',
                 durationMs: 8000,
               });
             }

--- a/src/app/kanban/[boardId]/page.tsx
+++ b/src/app/kanban/[boardId]/page.tsx
@@ -285,7 +285,12 @@ export default function KanbanBoardPage() {
 
   const handleImportToColumn = async (columnId: string): Promise<void> => {
     setTargetColumnId(columnId);
-    setOpenImportDialog(true);
+    if (extStatus === 'available') {
+      setOpenImportDialog(true);
+    } else {
+      // Extension not detected → behave like inbox: open manual import directly
+      setOpenManual(true);
+    }
   };
 
   const gridClass = useMemo(() => 'flex gap-3 overflow-x-auto pb-4', []);
@@ -377,15 +382,9 @@ export default function KanbanBoardPage() {
                 addToast({ variant: 'default', title: 'Nothing imported' });
               }
             } else {
+              // Extension not detected → go to manual import dialog directly
               setOpenImportDialog(false);
-              addToast({
-                variant: 'warning',
-                title: 'Extension not detected',
-                description: 'Please use manual import to add links into this column.',
-                linkHref: `?manualImport=1${targetColumnId ? `&columnId=${encodeURIComponent(targetColumnId)}` : ''}`,
-                linkLabel: 'Open manual import',
-                durationMs: 8000,
-              });
+              setOpenManual(true);
             }
           } catch (err) {
             if (err instanceof ApiError && err.isUnauthorized) {

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -90,7 +90,7 @@ function variantClasses(variant: ToastVariant): string {
 
 function Toaster({ toasts, onClose }: { readonly toasts: readonly Toast[]; readonly onClose: (id: string) => void }) {
   return (
-    <div className="pointer-events-none fixed left-1/2 top-4 z-[100] flex w-full max-w-lg -translate-x-1/2 flex-col items-center gap-2 px-3">
+    <div className="pointer-events-none fixed left-1/2 top-4 z-[100] flex w-full max-w-2xl -translate-x-1/2 flex-col items-center gap-2 px-3">
       {toasts.map((t) => (
         <div
           key={t.id}
@@ -105,17 +105,17 @@ function Toaster({ toasts, onClose }: { readonly toasts: readonly Toast[]; reado
                 <div className="mt-0.5 truncate text-xs opacity-80">{t.description}</div>
               ) : null}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex shrink-0 items-center gap-2 whitespace-nowrap">
               {t.linkHref ? (
                 <a
                   href={t.linkHref}
-                  className="rounded-md border px-2 py-1 text-xs text-foreground/80 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  className="rounded-md border px-2 py-1 text-xs text-foreground/80 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 whitespace-nowrap"
                 >
                   {t.linkLabel ?? 'View'}
                 </a>
               ) : null}
               <button
-                className="rounded-md border px-2 py-1 text-xs text-foreground/80 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="rounded-md border px-2 py-1 text-xs text-foreground/80 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 whitespace-nowrap"
                 onClick={() => onClose(t.id)}
               >
                 Close


### PR DESCRIPTION
## Background Description (Why)
- When importing to inbox/column with the extension installed, if there are no tabs to import, the UX should first show a prompt and provide a "manual import" entry, rather than directly switching to manual import.
- In Kanban space when "Extension: Not detected", the behavior should align with Inbox: directly open the manual import dialog to avoid additional steps and confusion.
- Toast UI breaks and squeezes when displaying long text and multiple actions, affecting readability and usability.

## Implementation Method (How)
- In the `inbox` and `kanban` import flows, when capture is empty, change to display a toast with a link to `?manualImport=1` (Kanban adds `&columnId=...`), and the page opens `ManualImportDialog` after detecting the query parameter, then uses `history.replaceState` to remove the parameter to prevent repeated triggering.
- Adjust Kanban's Import behavior: when extension is not detected, Import directly opens `ManualImportDialog` (aligning with Inbox).
- Improve `Toast` UI: widen the container to `max-w-2xl`, set the right action block to `shrink-0 whitespace-nowrap`, add `whitespace-nowrap` to buttons and links to prevent line breaks.

## Actual Changes (What was done)
- [x] Inbox: Display toast (with manual import link) when results are empty; support `?manualImport=1` to open `ManualImportDialog`.
- [x] Kanban: Display toast (with `columnId` link) when results are empty; support `?manualImport=1&columnId=...` to open `ManualImportDialog`.
- [x] Kanban: When extension is not detected, Import directly opens `ManualImportDialog` (no longer shows toast).
- [x] Toast UI: Adjust container width and make action blocks non-wrapping to improve readability and usability.

### Testing Verification
- [x] Inbox: Extension installed, currently only single tab → Press Import → Display "No tabs to import" toast, click "Open manual import" → Open `ManualImportDialog`.
- [x] Inbox: No extension → Press Import → Directly open `ManualImportDialog`.
- [x] Kanban: Extension installed, currently only single tab → Column Import → Display "No tabs to import" toast, click "Open manual import" → Open `ManualImportDialog` for corresponding column.
- [x] Kanban: No extension → Column Import → Directly open `ManualImportDialog` (no toast displayed).
- [x] Query trigger: `?manualImport=1` (Inbox) and `?manualImport=1&columnId=...` (Kanban) will open the dialog, and after `replaceState`, refresh/navigation won't trigger repeatedly.
- [x] Toast UI: Long descriptions and two actions (link + Close) won't break and squeeze, right actions stay on the same line.

## Additional Notes
- If accessibility needs enhancement, the toast link can be changed to a button that programmatically opens the dialog, avoiding reliance on URL queries.