### PR TITLE
Feat/cards-selection-and-title-behavior

### DIFF
--- a/src/app/api/telemetry/ui/route.ts
+++ b/src/app/api/telemetry/ui/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+
+import { getLogger } from '@/lib/observability/logger';
+import { getOrCreateCounter, measureApiHandler } from '@/lib/observability/metrics';
+
+export const runtime = 'nodejs';
+
+type UiEventBody = {
+  readonly name: string;
+  readonly data?: Record<string, unknown>;
+};
+
+export async function POST(req: NextRequest): Promise<Response> {
+  return measureApiHandler({ method: 'POST', route: '/api/telemetry/ui' }, async () => {
+    const logger = getLogger();
+    const counter = getOrCreateCounter('ui_events_total', 'Total UI events', { labelNames: ['name'] });
+
+    let body: UiEventBody | undefined;
+    try {
+      body = (await req.json()) as UiEventBody;
+    } catch {}
+
+    const name = body?.name ?? 'unknown';
+    const data = body?.data ?? {};
+
+    counter.labels(name).inc(1);
+    logger.info({ type: 'ui_event', name, data }, 'UI event');
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -308,15 +308,21 @@ function GridTabs({ tabs }: { tabs: ReadonlyArray<{ id: string; url: string; tit
     const container = e.currentTarget as HTMLElement;
     const nodes = Array.from(container.querySelectorAll('[role="gridcell"]')) as HTMLElement[];
     const cRect = container.getBoundingClientRect();
-    const sel = new Set(selected);
-    nodes.forEach((node) => {
-      const r = node.getBoundingClientRect();
-      const nx = r.left - cRect.left;
-      const ny = r.top - cRect.top;
-      const intersects = dragRect && !(nx > dragRect.left + dragRect.width || nx + r.width < dragRect.left || ny > dragRect.top + dragRect.height || ny + r.height < dragRect.top);
-      if (intersects) sel.add(node.dataset.itemId!);
-    });
-    setSelected(sel);
+    const isClick = !!dragRect && dragRect.width < 3 && dragRect.height < 3;
+    if (isClick) {
+      // Empty click clears selection (started only when not on a cell)
+      setSelected(new Set());
+    } else {
+      const sel = new Set(selected);
+      nodes.forEach((node) => {
+        const r = node.getBoundingClientRect();
+        const nx = r.left - cRect.left;
+        const ny = r.top - cRect.top;
+        const intersects = dragRect && !(nx > dragRect.left + dragRect.width || nx + r.width < dragRect.left || ny > dragRect.top + dragRect.height || ny + r.height < dragRect.top);
+        if (intersects) sel.add(node.dataset.itemId!);
+      });
+      setSelected(sel);
+    }
     setDragStart(null);
     setDragRect(null);
     try {

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -12,12 +12,12 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { useToast } from '@/components/ui/toast';
 import { Heading, Text } from '@/components/ui/typography';
 import { useExtensionStatus } from '@/hooks/use-extension-status';
+import { useHydrated } from '@/hooks/use-hydrated';
 import { ApiError } from '@/lib/api/errors';
 import { importTabsAndSyncLocalWithRaw } from '@/lib/data/import-tabs';
 import { type CapturedTab, captureOpenTabs } from '@/lib/extension/bridge';
 import { useInboxTabsNewest } from '@/lib/idb/hooks';
 import { ensureInboxAtEnd } from '@/lib/idb/inbox-repo';
-import { useHydrated } from '@/hooks/use-hydrated';
 
 export default function InboxPage() {
   const hydrated = useHydrated();

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -17,8 +17,10 @@ import { importTabsAndSyncLocalWithRaw } from '@/lib/data/import-tabs';
 import { type CapturedTab, captureOpenTabs } from '@/lib/extension/bridge';
 import { useInboxTabsNewest } from '@/lib/idb/hooks';
 import { ensureInboxAtEnd } from '@/lib/idb/inbox-repo';
+import { useHydrated } from '@/hooks/use-hydrated';
 
 export default function InboxPage() {
+  const hydrated = useHydrated();
   const [open, setOpen] = useState(false);
   const [openManual, setOpenManual] = useState(false);
   const extStatus = useExtensionStatus();
@@ -169,6 +171,10 @@ export default function InboxPage() {
 
       <div className="mt-4" role="grid" aria-label="Inbox tabs">
         {loading ? (
+          <Text size="sm" muted>
+            Loading...
+          </Text>
+        ) : !hydrated ? (
           <Text size="sm" muted>
             Loading...
           </Text>

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -347,6 +347,10 @@ function GridTabs({ tabs }: { tabs: ReadonlyArray<{ id: string; url: string; tit
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerCancel}
+      onClick={(e) => {
+        const isOnCell = (e.target as Element | null)?.closest?.('[role="gridcell"]');
+        if (!isOnCell) setSelected(new Set());
+      }}
     >
       {tabs.map((t) => (
         <TabCard

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -270,8 +270,14 @@ function GridTabs({ tabs }: { tabs: ReadonlyArray<{ id: string; url: string; tit
   const [dragRect, setDragRect] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
 
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    // mouse: only start when primary button is pressed; touch: always allow
+    // mouse: only start when primary button is pressed
     if (e.pointerType === 'mouse' && e.buttons !== 1) return;
+    // Do not start marquee when using selection modifiers; let card click handle shift/meta/ctrl logic
+    if (e.shiftKey || e.metaKey || e.ctrlKey) return;
+    // Do not start marquee if the pointerdown originated on a card
+    const isOnCell = (e.target as Element | null)?.closest?.('[role="gridcell"]');
+    if (isOnCell) return;
+
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -26,7 +26,7 @@ export default function LibraryPage() {
         Library
       </Heading>
 
-      <div className="mt-4">
+      <div className="mt-4" role="grid" aria-label="Library tabs">
         {loading ? (
           <Text size="sm" muted>
             Loading...

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,120 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+// no-op
 
 import { TabCard } from '@/components/tabs/tab-card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Heading, Text } from '@/components/ui/typography';
+import { useGridMultiSelect } from '@/hooks/use-grid-multi-select';
 import { useHydrated } from '@/hooks/use-hydrated';
 import { useAllTabsNewest } from '@/lib/idb/hooks';
 
 export default function LibraryPage() {
   const hydrated = useHydrated();
   const { tabs, loading } = useAllTabsNewest();
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-
-  const toggleSelect = (
-    id: string,
-    modifiers?: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean },
-  ) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if ((modifiers?.metaKey || modifiers?.ctrlKey) && next.has(id)) {
-        next.delete(id);
-        return next;
-      }
-      if (!modifiers?.shiftKey && !modifiers?.metaKey && !modifiers?.ctrlKey && next.has(id)) {
-        next.delete(id);
-        return next;
-      }
-      if (modifiers?.shiftKey && next.size > 0) {
-        // 簡化：用當前列表最後選取為 anchor
-        const indices = [...next].map((x) => tabs.findIndex((t) => t.id === x)).filter((i) => i >= 0).sort((a, b) => a - b);
-        const anchor = indices.length > 0 ? indices[indices.length - 1] : 0;
-        const target = tabs.findIndex((t) => t.id === id);
-        const [start, end] = anchor <= target ? [anchor, target] : [target, anchor];
-        for (let i = start; i <= end; i++) next.add(tabs[i]!.id);
-        return next;
-      }
-      if (modifiers?.metaKey || modifiers?.ctrlKey) {
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        return next;
-      }
-      next.clear();
-      next.add(id);
-      return next;
-    });
-  };
-
-  // Marquee selection state & handlers (mirror Inbox)
-  const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
-  const [dragRect, setDragRect] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
-
-  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    if (e.pointerType === 'mouse' && e.buttons !== 1) return;
-    if (e.shiftKey || e.metaKey || e.ctrlKey) return;
-    const isOnCell = (e.target as Element | null)?.closest?.('[role="gridcell"]');
-    if (isOnCell) return;
-
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    setDragStart({ x, y });
-    setDragRect({ left: x, top: y, width: 0, height: 0 });
-    try {
-      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    } catch {}
-    e.preventDefault();
-  };
-
-  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    if (!dragStart) return;
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    const left = Math.min(dragStart.x, x);
-    const top = Math.min(dragStart.y, y);
-    const width = Math.abs(x - dragStart.x);
-    const height = Math.abs(y - dragStart.y);
-    setDragRect({ left, top, width, height });
-    e.preventDefault();
-  };
-
-  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    if (!dragStart) return;
-    const container = e.currentTarget as HTMLElement;
-    const nodes = Array.from(container.querySelectorAll('[role="gridcell"]')) as HTMLElement[];
-    const cRect = container.getBoundingClientRect();
-    const isClick = !!dragRect && dragRect.width < 3 && dragRect.height < 3;
-    if (isClick) {
-      setSelected(new Set());
-    } else {
-      const sel = new Set(selected);
-      nodes.forEach((node) => {
-        const r = node.getBoundingClientRect();
-        const nx = r.left - cRect.left;
-        const ny = r.top - cRect.top;
-        const intersects = dragRect && !(nx > dragRect.left + dragRect.width || nx + r.width < dragRect.left || ny > dragRect.top + dragRect.height || ny + r.height < dragRect.top);
-        if (intersects) sel.add(node.dataset.itemId!);
-      });
-      setSelected(sel);
-    }
-    setDragStart(null);
-    setDragRect(null);
-    try {
-      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-    } catch {}
-    e.preventDefault();
-  };
-
-  const onPointerCancel: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    setDragStart(null);
-    setDragRect(null);
-    try {
-      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-    } catch {}
-  };
+  const { selectedIds, handleCardSelect, containerProps, dragRect } = useGridMultiSelect(tabs);
 
   return (
     <div className="min-h-[60svh] p-6">
@@ -132,21 +30,11 @@ export default function LibraryPage() {
             Loading...
           </Text>
         ) : tabs.length === 0 ? (
-          <EmptyState
-            title="No tabs yet"
-          />
+          <EmptyState title="No tabs yet" />
         ) : (
           <div
             className="relative grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
-            onClick={(e) => {
-              // click empty area clears selection
-              const isOnCell = (e.target as Element | null)?.closest?.('[role="gridcell"]');
-              if (!isOnCell) setSelected(new Set());
-            }}
-            onPointerDown={onPointerDown}
-            onPointerMove={onPointerMove}
-            onPointerUp={onPointerUp}
-            onPointerCancel={onPointerCancel}
+            {...containerProps}
           >
             {tabs.map((t) => (
               <TabCard
@@ -155,14 +43,19 @@ export default function LibraryPage() {
                 url={t.url}
                 title={t.title}
                 color={t.color}
-                selected={selected.has(t.id)}
-                onSelect={toggleSelect}
+                selected={selectedIds.has(t.id)}
+                onSelect={handleCardSelect}
               />
             ))}
             {dragRect ? (
               <div
                 className="pointer-events-none absolute z-10 border-2 border-success/70 bg-success/10"
-                style={{ left: dragRect.left, top: dragRect.top, width: dragRect.width, height: dragRect.height }}
+                style={{
+                  left: dragRect.left,
+                  top: dragRect.top,
+                  width: dragRect.width,
+                  height: dragRect.height,
+                }}
               />
             ) : null}
           </div>

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -11,11 +11,28 @@ export default function LibraryPage() {
   const { tabs, loading } = useAllTabsNewest();
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  const toggleSelect = (id: string) => {
+  const toggleSelect = (
+    id: string,
+    modifiers?: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean },
+  ) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (modifiers?.shiftKey && next.size > 0) {
+        // 簡化：用當前列表最後選取為 anchor
+        const indices = [...next].map((x) => tabs.findIndex((t) => t.id === x)).filter((i) => i >= 0).sort((a, b) => a - b);
+        const anchor = indices.length > 0 ? indices[indices.length - 1] : 0;
+        const target = tabs.findIndex((t) => t.id === id);
+        const [start, end] = anchor <= target ? [anchor, target] : [target, anchor];
+        for (let i = start; i <= end; i++) next.add(tabs[i]!.id);
+        return next;
+      }
+      if (modifiers?.metaKey || modifiers?.ctrlKey) {
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      }
+      next.clear();
+      next.add(id);
       return next;
     });
   };

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -17,6 +17,14 @@ export default function LibraryPage() {
   ) => {
     setSelected((prev) => {
       const next = new Set(prev);
+      if ((modifiers?.metaKey || modifiers?.ctrlKey) && next.has(id)) {
+        next.delete(id);
+        return next;
+      }
+      if (!modifiers?.shiftKey && !modifiers?.metaKey && !modifiers?.ctrlKey && next.has(id)) {
+        next.delete(id);
+        return next;
+      }
       if (modifiers?.shiftKey && next.size > 0) {
         // 簡化：用當前列表最後選取為 anchor
         const indices = [...next].map((x) => tabs.findIndex((t) => t.id === x)).filter((i) => i >= 0).sort((a, b) => a - b);
@@ -53,7 +61,7 @@ export default function LibraryPage() {
             title="No tabs yet"
           />
         ) : (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          <div className="relative grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
             {tabs.map((t) => (
               <TabCard
                 key={t.id}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -6,8 +6,10 @@ import { TabCard } from '@/components/tabs/tab-card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Heading, Text } from '@/components/ui/typography';
 import { useAllTabsNewest } from '@/lib/idb/hooks';
+import { useHydrated } from '@/hooks/use-hydrated';
 
 export default function LibraryPage() {
+  const hydrated = useHydrated();
   const { tabs, loading } = useAllTabsNewest();
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
@@ -53,6 +55,10 @@ export default function LibraryPage() {
 
       <div className="mt-4" role="grid" aria-label="Library tabs">
         {loading ? (
+          <Text size="sm" muted>
+            Loading...
+          </Text>
+        ) : !hydrated ? (
           <Text size="sm" muted>
             Loading...
           </Text>

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -5,8 +5,8 @@ import { useState } from 'react';
 import { TabCard } from '@/components/tabs/tab-card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Heading, Text } from '@/components/ui/typography';
-import { useAllTabsNewest } from '@/lib/idb/hooks';
 import { useHydrated } from '@/hooks/use-hydrated';
+import { useAllTabsNewest } from '@/lib/idb/hooks';
 
 export default function LibraryPage() {
   const hydrated = useHydrated();

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -61,7 +61,14 @@ export default function LibraryPage() {
             title="No tabs yet"
           />
         ) : (
-          <div className="relative grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          <div
+            className="relative grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+            onClick={(e) => {
+              // click empty area clears selection
+              const isOnCell = (e.target as Element | null)?.closest?.('[role="gridcell"]');
+              if (!isOnCell) setSelected(new Set());
+            }}
+          >
             {tabs.map((t) => (
               <TabCard
                 key={t.id}

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -16,17 +16,21 @@ const STORAGE_KEY = "tabseed.sidebar.collapsed";
 export function AppSidebar() {
   const pathname = usePathname();
   const extStatus = useExtensionStatus();
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
+  // IMPORTANT: Use a deterministic SSR initial state to avoid hydration mismatch.
+  // Read localStorage/matchMedia only after hydration.
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+
+  useEffect(() => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw != null) return raw === "1";
+      if (raw != null) {
+        setCollapsed(raw === "1");
+        return;
+      }
       const prefersNarrow = window.matchMedia && window.matchMedia("(max-width: 768px)").matches;
-      return prefersNarrow;
-    } catch {
-      return false;
-    }
-  });
+      setCollapsed(prefersNarrow);
+    } catch {}
+  }, []);
 
   useEffect(() => {
     try {

--- a/src/components/tabs/tab-card.test.tsx
+++ b/src/components/tabs/tab-card.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { TabCard } from './tab-card';
+
+describe('TabCard', () => {
+  it('toggles selection on Space and opens link on Enter', () => {
+    const onSelect = vi.fn();
+    render(<TabCard id="1" url="https://example.com" title="Example" onSelect={onSelect} />);
+
+    const cell = screen.getByRole('gridcell');
+    cell.focus();
+    fireEvent.keyDown(cell, { key: ' ' });
+    expect(onSelect).toHaveBeenCalled();
+
+    // mock window.open
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    fireEvent.keyDown(cell, { key: 'Enter' });
+    expect(openSpy).toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it('anchor has proper target and rel', () => {
+    render(<TabCard id="1" url="https://example.com" title="Example" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel');
+  });
+});
+
+

--- a/src/components/tabs/tab-card.test.tsx
+++ b/src/components/tabs/tab-card.test.tsx
@@ -3,6 +3,23 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { TabCard } from './tab-card';
 
 describe('TabCard', () => {
+  it('renders gridcell role and data-item-id, toggles aria-selected with selection', () => {
+    const onSelect = vi.fn();
+    render(
+      <TabCard
+        id="abc"
+        url="https://example.com"
+        title="Example"
+        selected={true}
+        onSelect={onSelect}
+      />,
+    );
+    const cell = screen.getByRole('gridcell');
+    expect(cell).toBeInTheDocument();
+    expect(cell).toHaveAttribute('data-item-id', 'abc');
+    expect(cell).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('toggles selection on Space and opens link on Enter', () => {
     const onSelect = vi.fn();
     render(<TabCard id="1" url="https://example.com" title="Example" onSelect={onSelect} />);

--- a/src/components/tabs/tab-card.test.tsx
+++ b/src/components/tabs/tab-card.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { TabCard } from './tab-card';
 
@@ -27,5 +26,3 @@ describe('TabCard', () => {
     expect(link).toHaveAttribute('rel');
   });
 });
-
-

--- a/src/components/tabs/tab-card.tsx
+++ b/src/components/tabs/tab-card.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 
 import { cn } from '@/lib/utils';
 import { postUiEvent } from '@/lib/observability/ui';
@@ -9,7 +10,10 @@ export interface TabCardProps {
   readonly title?: string;
   readonly color?: string;
   readonly selected?: boolean;
-  readonly onSelect?: (id: string) => void;
+  readonly onSelect?: (
+    id: string,
+    modifiers?: { readonly shiftKey?: boolean; readonly metaKey?: boolean; readonly ctrlKey?: boolean; readonly via?: 'click' | 'space' }
+  ) => void;
   readonly disableClick?: boolean;
 }
 
@@ -18,9 +22,9 @@ export function TabCard({ id, url, title, color, selected, onSelect, disableClic
     <div
       role="gridcell"
       aria-selected={onSelect ? (selected ? true : false) : undefined}
-      onClick={() => {
+      onClick={(e) => {
         if (onSelect) {
-          onSelect(id);
+          onSelect(id, { shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, via: 'click' });
         }
       }}
       tabIndex={onSelect ? 0 : undefined}
@@ -28,7 +32,7 @@ export function TabCard({ id, url, title, color, selected, onSelect, disableClic
         if (!onSelect) return;
         if (e.key === ' ') {
           e.preventDefault();
-          onSelect(id);
+          onSelect(id, { shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, via: 'space' });
           return;
         }
         if (e.key === 'Enter') {

--- a/src/components/tabs/tab-card.tsx
+++ b/src/components/tabs/tab-card.tsx
@@ -20,6 +20,7 @@ export interface TabCardProps {
 export function TabCard({ id, url, title, color, selected, onSelect, disableClick }: TabCardProps) {
   return (
     <div
+      data-item-id={id}
       role="gridcell"
       aria-selected={onSelect ? (selected ? true : false) : undefined}
       onClick={(e) => {

--- a/src/components/tabs/tab-card.tsx
+++ b/src/components/tabs/tab-card.tsx
@@ -45,7 +45,7 @@ export function TabCard({ id, url, title, color, selected, onSelect, disableClic
         }
       }}
       className={cn(
-        'group block rounded-lg border bg-card p-3 text-card-foreground shadow-elev-1 transition-[transform,box-shadow] duration-200 ease-emphasized hover:-translate-y-0.5 hover:shadow-elev-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'group block rounded-lg border bg-card p-3 text-card-foreground shadow-elev-1 transition-[transform,box-shadow] duration-200 ease-emphasized hover:-translate-y-0.5 hover:shadow-elev-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-success focus-visible:ring-offset-2',
         selected && 'ring-2 ring-success',
       )}
       style={color ? ({ borderColor: color } as React.CSSProperties) : undefined}

--- a/src/components/tabs/tab-card.tsx
+++ b/src/components/tabs/tab-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@/lib/utils';
+import { postUiEvent } from '@/lib/observability/ui';
 
 export interface TabCardProps {
   readonly id: string;
@@ -15,18 +16,28 @@ export interface TabCardProps {
 export function TabCard({ id, url, title, color, selected, onSelect, disableClick }: TabCardProps) {
   return (
     <div
+      role="gridcell"
+      aria-selected={onSelect ? (selected ? true : false) : undefined}
       onClick={() => {
         if (onSelect) {
           onSelect(id);
         }
       }}
-      role={onSelect ? 'button' : undefined}
       tabIndex={onSelect ? 0 : undefined}
       onKeyDown={(e) => {
         if (!onSelect) return;
-        if (e.key === 'Enter' || e.key === ' ') {
+        if (e.key === ' ') {
           e.preventDefault();
           onSelect(id);
+          return;
+        }
+        if (e.key === 'Enter') {
+          // Enter 開啟 title 連結（新分頁）
+          e.preventDefault();
+          try {
+            window.open(url, '_blank', 'noopener,noreferrer');
+            void postUiEvent('card.open_link', { id, via: 'enter' });
+          } catch {}
         }
       }}
       className={cn(
@@ -46,6 +57,7 @@ export function TabCard({ id, url, title, color, selected, onSelect, disableClic
               e.preventDefault();
               return;
             }
+            void postUiEvent('card.open_link', { id, via: 'click' });
           }}
           onMouseDown={(e) => {
             // Prevent drag handlers in parent contexts (e.g., Kanban) from capturing pointer

--- a/src/components/tabs/tab-card.tsx
+++ b/src/components/tabs/tab-card.tsx
@@ -1,8 +1,8 @@
 'use client';
 import React from 'react';
 
-import { cn } from '@/lib/utils';
 import { postUiEvent } from '@/lib/observability/ui';
+import { cn } from '@/lib/utils';
 
 export interface TabCardProps {
   readonly id: string;

--- a/src/hooks/use-grid-multi-select.test.tsx
+++ b/src/hooks/use-grid-multi-select.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useGridMultiSelect } from './use-grid-multi-select';
+
+function Grid({ items }: { items: { id: string }[] }) {
+  const { selectedIds, handleCardSelect, containerProps, dragRect } = useGridMultiSelect(items);
+  return (
+    <div data-testid="grid" role="grid" {...containerProps}>
+      <div className="grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr' }}>
+        {items.map((it) => (
+          <div
+            key={it.id}
+            role="gridcell"
+            data-item-id={it.id}
+            onClick={(e) =>
+              handleCardSelect(it.id, {
+                metaKey: e.metaKey,
+                ctrlKey: e.ctrlKey,
+                shiftKey: e.shiftKey,
+              })
+            }
+            tabIndex={0}
+          >
+            {it.id} {selectedIds.has(it.id) ? 'selected' : ''}
+          </div>
+        ))}
+        {dragRect ? (
+          <div
+            data-testid="marquee"
+            style={{
+              left: dragRect.left,
+              top: dragRect.top,
+              width: dragRect.width,
+              height: dragRect.height,
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+describe('useGridMultiSelect', () => {
+  const items = Array.from({ length: 9 }).map((_, i) => ({ id: String(i + 1) }));
+
+  it('single click selects and toggles', () => {
+    render(<Grid items={items} />);
+    const cell1 = screen.getAllByRole('gridcell')[0]!;
+    fireEvent.click(cell1);
+    expect(cell1.textContent).toContain('selected');
+    fireEvent.click(cell1);
+    expect(cell1.textContent).not.toContain('selected');
+  });
+
+  it('meta/ctrl adds to selection', () => {
+    render(<Grid items={items} />);
+    const [c1, c2] = screen.getAllByRole('gridcell');
+    fireEvent.click(c1);
+    fireEvent.click(c2, { metaKey: true });
+    expect(c1.textContent).toContain('selected');
+    expect(c2.textContent).toContain('selected');
+  });
+
+  it('shift selects range based on last anchor', () => {
+    render(<Grid items={items} />);
+    const cells = screen.getAllByRole('gridcell');
+    fireEvent.click(cells[1]); // select 2
+    fireEvent.click(cells[5], { shiftKey: true }); // 2..6
+    for (let i = 1; i <= 5; i++) {
+      expect(cells[i].textContent).toContain('selected');
+    }
+  });
+
+  it('click empty area clears selection', () => {
+    render(<Grid items={items} />);
+    const cells = screen.getAllByRole('gridcell');
+    fireEvent.click(cells[0]);
+    expect(cells[0].textContent).toContain('selected');
+    const grid = screen.getByTestId('grid');
+    fireEvent.click(grid);
+    expect(cells[0].textContent).not.toContain('selected');
+  });
+
+  it('marquee selects intersecting cells', () => {
+    render(<Grid items={items} />);
+    const grid = screen.getByTestId('grid');
+    // jsdom lacks layout; simulate pointer events without relying on real coordinates
+    // We still invoke the handlers to ensure state transitions run without errors
+    fireEvent.pointerDown(grid, { clientX: 10, clientY: 10, buttons: 1 });
+    fireEvent.pointerMove(grid, { clientX: 50, clientY: 50, buttons: 1 });
+    fireEvent.pointerUp(grid, { clientX: 50, clientY: 50 });
+    // Cannot assert exact selection without real layout, just ensure no crash
+    expect(screen.getByTestId('grid')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/use-grid-multi-select.ts
+++ b/src/hooks/use-grid-multi-select.ts
@@ -1,0 +1,178 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type Modifiers = {
+  readonly shiftKey?: boolean;
+  readonly metaKey?: boolean;
+  readonly ctrlKey?: boolean;
+};
+
+export interface UseGridMultiSelectOptions {
+  readonly gridCellSelector?: string;
+  readonly minDragDistance?: number;
+}
+
+export interface UseGridMultiSelectResult {
+  readonly selectedIds: ReadonlySet<string>;
+  readonly isSelected: (id: string) => boolean;
+  readonly handleCardSelect: (id: string, modifiers?: Modifiers) => void;
+  readonly clearSelection: () => void;
+  readonly containerProps: {
+    onPointerDown: React.PointerEventHandler<HTMLDivElement>;
+    onPointerMove: React.PointerEventHandler<HTMLDivElement>;
+    onPointerUp: React.PointerEventHandler<HTMLDivElement>;
+    onPointerCancel: React.PointerEventHandler<HTMLDivElement>;
+    onClick: React.MouseEventHandler<HTMLDivElement>;
+  };
+  readonly dragRect: { left: number; top: number; width: number; height: number } | null;
+}
+
+/**
+ * Reusable multi-select hook for grid of cards with click/shift/meta and marquee selection.
+ */
+export function useGridMultiSelect<TItem extends { id: string }>(
+  items: ReadonlyArray<TItem>,
+  options?: UseGridMultiSelectOptions,
+): UseGridMultiSelectResult {
+  const gridCellSelector = options?.gridCellSelector ?? '[role="gridcell"]';
+  const minDrag = options?.minDragDistance ?? 3;
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
+  const [dragRect, setDragRect] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const idToIndex = useMemo(() => new Map(items.map((t, i) => [t.id, i])), [items]);
+
+  const handleCardSelect = (id: string, modifiers?: Modifiers) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if ((modifiers?.metaKey || modifiers?.ctrlKey) && next.has(id)) {
+        next.delete(id);
+        return next;
+      }
+      if (!modifiers?.shiftKey && !modifiers?.metaKey && !modifiers?.ctrlKey && next.has(id)) {
+        next.delete(id);
+        return next;
+      }
+      if (modifiers?.shiftKey && next.size > 0) {
+        const indices = [...next]
+          .map((x) => idToIndex.get(x) ?? -1)
+          .filter((i) => i >= 0)
+          .sort((a, b) => a - b);
+        const anchor = indices.length > 0 ? indices[indices.length - 1] : 0;
+        const target = idToIndex.get(id) ?? 0;
+        const [start, end] = anchor <= target ? [anchor, target] : [target, anchor];
+        for (let i = start; i <= end; i++) next.add(items[i]!.id);
+        return next;
+      }
+      if (modifiers?.metaKey || modifiers?.ctrlKey) {
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      }
+      next.clear();
+      next.add(id);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelected(new Set());
+
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (e.pointerType === 'mouse' && e.buttons !== 1) return;
+    if (e.shiftKey || e.metaKey || e.ctrlKey) return;
+    const isOnCell = (e.target as Element | null)?.closest?.(gridCellSelector);
+    if (isOnCell) return;
+
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setDragStart({ x, y });
+    setDragRect({ left: x, top: y, width: 0, height: 0 });
+    try {
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    } catch {}
+    e.preventDefault();
+  };
+
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!dragStart) return;
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const left = Math.min(dragStart.x, x);
+    const top = Math.min(dragStart.y, y);
+    const width = Math.abs(x - dragStart.x);
+    const height = Math.abs(y - dragStart.y);
+    setDragRect({ left, top, width, height });
+    e.preventDefault();
+  };
+
+  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (!dragStart) return;
+    const container = e.currentTarget as HTMLElement;
+    const nodes = Array.from(container.querySelectorAll(gridCellSelector)) as HTMLElement[];
+    const cRect = container.getBoundingClientRect();
+    const isClick = !!dragRect && dragRect.width < minDrag && dragRect.height < minDrag;
+    if (isClick) {
+      setSelected(new Set());
+    } else {
+      const sel = new Set(selected);
+      nodes.forEach((node) => {
+        const r = node.getBoundingClientRect();
+        const nx = r.left - cRect.left;
+        const ny = r.top - cRect.top;
+        const intersects =
+          !!dragRect &&
+          !(
+            nx > dragRect.left + dragRect.width ||
+            nx + r.width < dragRect.left ||
+            ny > dragRect.top + dragRect.height ||
+            ny + r.height < dragRect.top
+          );
+        if (intersects) sel.add(node.dataset.itemId!);
+      });
+      setSelected(sel);
+    }
+    setDragStart(null);
+    setDragRect(null);
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {}
+    e.preventDefault();
+  };
+
+  const onPointerCancel: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    setDragStart(null);
+    setDragRect(null);
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {}
+  };
+
+  const onClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    const isOnCell = (e.target as Element | null)?.closest?.(gridCellSelector);
+    if (!isOnCell) setSelected(new Set());
+  };
+
+  return {
+    selectedIds: selected,
+    isSelected: (id: string) => selected.has(id),
+    handleCardSelect: handleCardSelect,
+    clearSelection,
+    containerProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onClick,
+    },
+    dragRect,
+  };
+}

--- a/src/hooks/use-hydrated.ts
+++ b/src/hooks/use-hydrated.ts
@@ -6,6 +6,9 @@ export function useHydrated(): boolean {
   const [hydrated, setHydrated] = useState(false);
   useEffect(() => {
     setHydrated(true);
+    try {
+      sessionStorage.setItem('tabseed.__hydrated', '1');
+    } catch {}
   }, []);
   return hydrated;
 }

--- a/src/hooks/use-hydrated.ts
+++ b/src/hooks/use-hydrated.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useHydrated(): boolean {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+  return hydrated;
+}
+
+

--- a/src/hooks/use-hydrated.ts
+++ b/src/hooks/use-hydrated.ts
@@ -9,5 +9,3 @@ export function useHydrated(): boolean {
   }, []);
   return hydrated;
 }
-
-

--- a/src/lib/observability/ui.ts
+++ b/src/lib/observability/ui.ts
@@ -1,0 +1,14 @@
+export async function postUiEvent(name: string, data?: Record<string, unknown>): Promise<void> {
+  try {
+    await fetch('/api/telemetry/ui', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, data }),
+      keepalive: true,
+    });
+  } catch {
+    // Best-effort only
+  }
+}
+
+


### PR DESCRIPTION
## Background Description (Why)
- Improve Inbox/Library selection experience and accessibility (a11y): Support multi-selection, keyboard operations, and semantic ARIA labeling.
- Add UI telemetry: Track key UI interaction events for performance monitoring and user behavior analysis.
- Solve/avoid hydration mismatch: Use stable SSR defaults for sidebar initial state and restore preferences on client side to reduce flickering and inconsistency.

## Implementation Approach (How)
- Multi-select
  - Add `useGridMultiSelect` hook to uniformly handle single selection/range selection (Shift)/cumulative selection (Ctrl/Cmd) and drag marquee selection.
  - Adjust `TabCard` to `role="gridcell"`, `aria-selected`, and provide richer `onSelect(id, modifiers)` signature.
- Keyboard/Accessibility
  - Change Inbox to `GridTabs` component: Add arrow key navigation in grid layout, `Enter` to open new tab, `Space` to toggle selection.
  - Mark Inbox/Library containers as `role="grid"`, `aria-label`, each card as `role="gridcell"`.
- Telemetry
  - Add `POST /api/telemetry/ui`, use `@/lib/observability/logger` to record and `getOrCreateCounter('ui_events_total', { label: name })` to accumulate.
  - Send `postUiEvent('card.open_link', {...})` in `TabCard` for "click/Enter to open link".
- Hydration
  - Use predictable SSR initial values in `AppSidebar`, restore with `localStorage`/`prefersNarrow` after mounting; avoid hydration mismatch and initial load flickering.
- Visual/Focus
  - Change card focus style to `ring-success`, selection state to `ring-success` presentation, consistent with product color scheme.

## Actual Changes (What was done)
- New API
  - `src/app/api/telemetry/ui/route.ts`: `POST /api/telemetry/ui` (Node runtime), record `ui_event` and accumulate `ui_events_total{name}`.
- UI/Logic
  - `src/app/inbox/page.tsx`: Import `useGridMultiSelect`, `useHydrated`; extract `GridTabs`, support keyboard navigation, a11y labeling and marquee overlay.
  - `src/app/library/page.tsx`: Similarly import multi-select and hydration gating.
  - `src/components/tabs/tab-card.tsx`: Change semantics to `gridcell`, `aria-selected`; `Space` to toggle selection, `Enter` to open link with `window.open` and report telemetry.
  - `src/components/app/app-sidebar.tsx`: Fix SSR initial state to `false`, restore `localStorage`/media query preference after mounting, avoid mismatch.
- Testing
  - `src/components/tabs/tab-card.test.tsx`: Render/ARIA/keyboard behavior tests (Space/Enter, link target/rel).
  - `src/hooks/use-grid-multi-select.test.tsx`: Single selection, Shift range, Ctrl/Cmd cumulative, click empty to clear and drag marquee selection flow.

### Testing Verification
- [x] Inbox/Library
  - [x] `role="grid"` + `role="gridcell"` + `aria-selected` render correctly
  - [x] Arrow keys move focus between grid elements
  - [x] Space toggles selection; Ctrl/Cmd appends selection; Shift selects range from last anchor
  - [x] Click empty area clears selection; drag marquee shows overlay, no exception thrown after completion
- [x] TabCard
  - [x] Enter opens link in new tab, `target="_blank"` and `rel` includes `noopener,noreferrer`
  - [x] `onSelect` modifier key information passes correctly
- [x] Telemetry
  - [x] `POST /api/telemetry/ui` returns 200 and increments `ui_events_total{name}`, logger records `type=ui_event`
  - [x] `postUiEvent('card.open_link', ...)` triggered on click/Enter
- [x] Hydration/SSR
  - [x] No hydration mismatch warning on first SSR
  - [x] Can restore sidebar "collapse" preference from `localStorage` after mounting